### PR TITLE
#2: Add a section about supported browsers

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -23,6 +23,11 @@ domLoaded.then(() => {
 ```
 
 
+## Supported browsers
+
+All good if [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) is available in your browser. https://caniuse.com/#feat=promises
+
+
 ## Related
 
 - [element-ready](https://github.com/sindresorhus/element-ready) - Detect when an element is ready in the DOM


### PR DESCRIPTION
In my personal opinion, it's good to have browsers compatibility note at the repository's main page (https://github.com/sindresorhus/dom-loaded/issues/2) because some of the packages that using `dom-loaded` might wrongly declare they support, let's say, IE11 (example - https://github.com/nk-o/jarallax/issues/101).